### PR TITLE
Fixed up to date status issue #10

### DIFF
--- a/agent/security.vbs
+++ b/agent/security.vbs
@@ -78,7 +78,7 @@ if Not IsNull (objWMIService_AV) Then
       If Mid(dec2bin(objAVP.ProductState),12,1) = "1" Then productEnabled = "1"
  
       productUptoDate = "0"
-      If Mid(dec2bin(objAVP.ProductState),16,8) = "00000000" Then productUptoDate = "1"
+      If Mid(dec2bin(objAVP.ProductState),17,8) = "00000000" Then productUptoDate = "1"
  
       writeXML "2", arrCat(a), strCompanyName, objAVP.displayName, strVersionNumber, productEnabled, productUptoDate
       arrNbr(a) = arrNbr(a) + 1


### PR DESCRIPTION
The third byte of the status variable starts from index 17, not 16, since the `Mid` method is 1-indexed. This will ensure that the Up To Date status for Windows Defender (and other Antiviruses) is correctly reported.